### PR TITLE
changes link to our test bench apps, adds hapi 16

### DIFF
--- a/index.html
+++ b/index.html
@@ -508,7 +508,7 @@
   <br>
 
   <!--
-     
+
       Incident Management
 
     -->
@@ -558,7 +558,7 @@
   <br>
   <br>
 
-  <!--      
+  <!--
 
       SIEM Integrations
 
@@ -623,7 +623,7 @@
   <br>
   <br>
 
-  <!--  
+  <!--
 
     Browser Extensions
 
@@ -867,51 +867,25 @@
           </div>
           <div class="bg-light mr-md-3 pt-3 px-3 pt-md-5 px-md-5 text-center overflow-hidden contrast-box">
               <div class="my-3 py-3">
-                  <img src="img/express.png" class="ide-icon-wide">
-                  <h2 class="display-5 contrast-item-heading">Express Test Bench</h2>
-                  <p class="lead item-lead">Intentionally vulnerable Express application
+                  <img src="img/nodejs.png" class="ide-icon-wide">
+                  <h2 class="display-5 contrast-item-heading">Node Test Bench Apps</h2>
+                  <p class="lead item-lead">Intentionally vulnerable applications for: Express, Hapi, Koa, Kraken, Fastify and Loopback.
                       <br/>&nbsp;</p>
 
                   <div class="links">
-                      <a class="link source-link" href="https://github.com/Contrast-Security-OSS/NodeTestBench">Source code</a>
+                      <a class="link source-link" target="_blank" href="https://github.com/Contrast-Security-OSS/NodeTestBenches">Source code</a>
                   </div>
               </div>
           </div>
           <div class="bg-light mr-md-3 pt-3 px-3 pt-md-5 px-md-5 text-center overflow-hidden contrast-box">
               <div class="my-3 py-3">
                   <img src="img/hapi.png" class="ide-icon-big">
-                  <h2 class="display-5 contrast-item-heading">Hapi Test Bench</h2>
-                  <p class="lead item-lead">Intentionally vulnerable Hapi application
+                  <h2 class="display-5 contrast-item-heading">Hapi 16 Test Bench</h2>
+                  <p class="lead item-lead">Intentionally vulnerable Hapi 16 application
                       <br/>&nbsp;</p>
 
                   <div class="links">
-                      <a class="link source-link" href="https://github.com/Contrast-Security-OSS/HapiTestBench">Source code</a>
-                  </div>
-              </div>
-          </div>
-      </div>
-      <div class="d-md-flex flex-md-equal w-100 my-md-3 pl-md-3">
-          <div class="bg-light mr-md-3 pt-3 px-3 pt-md-5 px-md-5 text-center overflow-hidden contrast-box">
-              <div class="my-3 py-3">
-                  <img src="img/koa.png" class="ide-icon-big">
-                  <h2 class="display-5 contrast-item-heading">Koa Test Bench</h2>
-                  <p class="lead item-lead">Intentionally vulnerable Koa application
-                      <br/>&nbsp;</p>
-
-                  <div class="links">
-                      <a class="link source-link" href="https://github.com/Contrast-Security-OSS/KoaTestBench">Source code</a>
-                  </div>
-              </div>
-          </div>
-          <div class="bg-light mr-md-3 pt-3 px-3 pt-md-5 px-md-5 text-center overflow-hidden contrast-box">
-              <div class="my-3 py-3">
-                  <img src="img/kraken.png" class="ide-icon-big">
-                  <h2 class="display-5 contrast-item-heading">Kraken Test Bench</h2>
-                  <p class="lead item-lead">Intentionally vulnerable Kraken application
-                      <br/>&nbsp;</p>
-
-                  <div class="links">
-                      <a class="link source-link" href="https://github.com/Contrast-Security-OSS/KrakenTestBench">Source code</a>
+                      <a class="link source-link" target="_blank" href="https://github.com/Contrast-Security-OSS/Hapi16TestBench">Source code</a>
                   </div>
               </div>
           </div>
@@ -968,7 +942,7 @@
           </div>
       </div>
   </footer>
-  
+
 </body>
 
 </html>


### PR DESCRIPTION
We consolidated our test bench apps to a mono repo excluding Hapi 16, updated links and descriptions accordingly