### PR TITLE
:bug: Fix Broken Java Links

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
                   <div class="links">
                       <a class="link source-link" href="https://docs.contrastsecurity.com/installation-nodeintegrations.html#cloud-foundry">For Node.js</a>
                       <br/>
-                      <a class="link source-link" href="https://docs.contrastsecurity.com/installation-javaserver.html#cloud">For Java</a>
+                      <a class="link source-link" href="https://docs.contrastsecurity.com/en/vmware-tanzu-network-for-java.html">For Java</a>
                   </div>
               </div>
           </div>
@@ -104,7 +104,7 @@
                   <br>
                   <h3 class="display-5">Google<br>App Engine</h3>
                   <div class="links">
-                      <a class="link source-link" href="https://docs.contrastsecurity.com/installation-javaserver.html#google">For Java</a>
+                      <a class="link source-link" href="https://docs.contrastsecurity.com/en/google-app-engine.html">For Java</a>
                       <br/>
                   </div>
               </div>
@@ -118,7 +118,7 @@
                   <h3 class="display-5">AWS<br>Elastic Beanstalk</h3>
 
                   <div class="links">
-                      <a class="link source-link" href="https://docs.contrastsecurity.com/installation-javaserver.html#aws">For Java</a>
+                      <a class="link source-link" href="https://docs.contrastsecurity.com/en/aws-elastic-beanstalk.html">For Java</a>
                   </div>
               </div>
           </div>


### PR DESCRIPTION
The link redirection on docs.contrastsecurity.com won't work for some of these old links with document fragments 😔. I updated to the new links.